### PR TITLE
refactor: simplify UX - remove redundant buttons and menu

### DIFF
--- a/hooks/slack-notify-waiting.sh
+++ b/hooks/slack-notify-waiting.sh
@@ -1,39 +1,29 @@
 #!/bin/bash
-# Slack notification when Claude Code needs input (Notification hook)
-# Sends a Bot DM with tmux pane capture showing what Claude is asking,
-# plus Block Kit Approve/Deny buttons for one-tap response.
-#
-# Hook type: Notification
-# Matcher: permission_prompt
-# Trigger: Claude Code requests permission (e.g., to run a bash command)
-#
-# Required env vars (via .env or environment):
-#   SLACK_NOTIFY_ENABLED=true
-#   SLACK_BOT_TOKEN=xoxb-...
-#   SLACK_ALLOWED_USER=U...
-#   TMUX_SESSION_NAME=claude (optional, default: claude)
+# Slack 入力待ち通知スクリプト（Bot DM版）
+# Claude Code の Notification フックから呼び出され、承認待ち時に Bot DM に通知を送信する
+# tmux 画面キャプチャを含めて、何を問われているかを明確に伝える
 
-# --- Load environment variables ---
-for ENV_FILE in "./.env" "$HOME/.config/ai-agents/profiles/default.env"; do
-  if [ -f "$ENV_FILE" ]; then
-    [ -z "$SLACK_NOTIFY_ENABLED" ] && SLACK_NOTIFY_ENABLED=$(grep '^SLACK_NOTIFY_ENABLED=' "$ENV_FILE" | cut -d'=' -f2)
-    [ -z "$SLACK_BOT_TOKEN" ] && SLACK_BOT_TOKEN=$(grep '^SLACK_BOT_TOKEN=' "$ENV_FILE" | cut -d'=' -f2)
-    [ -z "$SLACK_ALLOWED_USER" ] && SLACK_ALLOWED_USER=$(grep '^SLACK_ALLOWED_USER=' "$ENV_FILE" | cut -d'=' -f2)
-    [ -z "$TMUX_SESSION_NAME" ] && TMUX_SESSION_NAME=$(grep '^TMUX_SESSION_NAME=' "$ENV_FILE" | cut -d'=' -f2)
-  fi
-done
+ENV_FILE="$HOME/.config/ai-agents/profiles/default.env"
+
+# 環境変数読み込み
+if [ -f "$ENV_FILE" ]; then
+  SLACK_NOTIFY_ENABLED=$(grep '^SLACK_NOTIFY_ENABLED=' "$ENV_FILE" | cut -d'=' -f2)
+  SLACK_BOT_TOKEN=$(grep '^SLACK_BOT_TOKEN=' "$ENV_FILE" | cut -d'=' -f2)
+  SLACK_ALLOWED_USER=$(grep '^SLACK_ALLOWED_USER=' "$ENV_FILE" | cut -d'=' -f2)
+  TMUX_SESSION_NAME=$(grep '^TMUX_SESSION_NAME=' "$ENV_FILE" | cut -d'=' -f2)
+fi
 
 TMUX_SESSION_NAME="${TMUX_SESSION_NAME:-claude}"
 
-# Exit if disabled or missing config
+# 無効なら即終了
 [ "$SLACK_NOTIFY_ENABLED" = "true" ] || exit 0
 [ -n "$SLACK_BOT_TOKEN" ] || exit 0
 [ -n "$SLACK_ALLOWED_USER" ] || exit 0
 
-# Read JSON from stdin
+# stdin から JSON を読み取り
 INPUT=$(cat)
 
-# Build and send notification via Python
+# 環境変数を設定してからバックグラウンド実行
 export HOOK_INPUT="$INPUT"
 export TMUX_SESSION_NAME
 export BOT_TOKEN="$SLACK_BOT_TOKEN"
@@ -44,6 +34,7 @@ python3 << 'PYEOF'
 import json, subprocess, sys, os, urllib.request
 from datetime import datetime
 
+# 入力解析
 try:
     data = json.loads(os.environ.get("HOOK_INPUT", "{}"))
 except:
@@ -60,7 +51,7 @@ allowed_user = os.environ.get("ALLOWED_USER", "")
 if not bot_token or not allowed_user:
     sys.exit(0)
 
-# Auto-detect current tmux session name
+# 実行中の tmux セッション名を検出（環境変数 TMUX から自動判定）
 try:
     detect = subprocess.run(
         ["tmux", "display-message", "-p", "#{session_name}"],
@@ -71,7 +62,7 @@ try:
 except:
     pass
 
-# Capture tmux pane to show what Claude is actually asking
+# tmux 画面キャプチャ（末尾部分）- 実際の許可プロンプト内容を取得
 pane_content = ""
 try:
     result = subprocess.run(
@@ -84,32 +75,33 @@ try:
 except:
     pass
 
-# Build message (Block Kit)
-header_text = f":double_vertical_bar: *Waiting for input: {dir_name}*\n:speech_balloon: {message}\n:clock3: {time_str}"
+# メッセージ組み立て（Block Kit）
+header_text = f":double_vertical_bar: *入力待ち: {dir_name}*\n:speech_balloon: {message}\n:clock3: {time_str}"
 
 blocks = [
     {"type": "section", "text": {"type": "mrkdwn", "text": header_text}},
 ]
 
 if pane_content:
+    # Slack の code block は最大 3000 文字程度
     if len(pane_content) > 2500:
         pane_content = "...\n" + pane_content[-2500:]
     blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": f"```\n{pane_content}\n```"}})
 
-# Approve/Deny buttons (action_ids match hook_approve/hook_deny handlers in bot.py)
+# 許可/拒否ボタン（action_id は bot.py の hook_approve / hook_deny ハンドラに対応）
 blocks.append({
     "type": "actions",
     "elements": [
         {
             "type": "button",
-            "text": {"type": "plain_text", "text": "Approve (y)"},
+            "text": {"type": "plain_text", "text": "✅ 許可 (y)"},
             "action_id": "hook_approve",
             "value": tmux_session,
             "style": "primary",
         },
         {
             "type": "button",
-            "text": {"type": "plain_text", "text": "Deny (n)"},
+            "text": {"type": "plain_text", "text": "❌ 拒否 (n)"},
             "action_id": "hook_deny",
             "value": tmux_session,
             "style": "danger",
@@ -117,18 +109,20 @@ blocks.append({
     ],
 })
 
-fallback_text = f"Waiting for input: {dir_name} - {message}"
+fallback_text = f"入力待ち: {dir_name} - {message}"
 
-# Send via Bot DM
+# Bot DM で送信
 headers = {
     "Authorization": f"Bearer {bot_token}",
     "Content-Type": "application/json; charset=utf-8",
 }
 
+# conversations.open
 req = urllib.request.Request(
     "https://slack.com/api/conversations.open",
     data=json.dumps({"users": allowed_user}).encode("utf-8"),
-    headers=headers, method="POST",
+    headers=headers,
+    method="POST",
 )
 try:
     with urllib.request.urlopen(req, timeout=10) as resp:
@@ -139,6 +133,7 @@ except:
 if not channel_id:
     sys.exit(0)
 
+# chat.postMessage（Block Kit）
 payload = {
     "channel": channel_id,
     "text": fallback_text,
@@ -147,12 +142,14 @@ payload = {
 req2 = urllib.request.Request(
     "https://slack.com/api/chat.postMessage",
     data=json.dumps(payload).encode("utf-8"),
-    headers=headers, method="POST",
+    headers=headers,
+    method="POST",
 )
 try:
     urllib.request.urlopen(req2, timeout=10)
 except:
     pass
+
 PYEOF
 ) &
 

--- a/skill/hooks/slack-notify-waiting.sh
+++ b/skill/hooks/slack-notify-waiting.sh
@@ -1,39 +1,29 @@
 #!/bin/bash
-# Slack notification when Claude Code needs input (Notification hook)
-# Sends a Bot DM with tmux pane capture showing what Claude is asking,
-# plus Block Kit Approve/Deny buttons for one-tap response.
-#
-# Hook type: Notification
-# Matcher: permission_prompt
-# Trigger: Claude Code requests permission (e.g., to run a bash command)
-#
-# Required env vars (via .env or environment):
-#   SLACK_NOTIFY_ENABLED=true
-#   SLACK_BOT_TOKEN=xoxb-...
-#   SLACK_ALLOWED_USER=U...
-#   TMUX_SESSION_NAME=claude (optional, default: claude)
+# Slack 入力待ち通知スクリプト（Bot DM版）
+# Claude Code の Notification フックから呼び出され、承認待ち時に Bot DM に通知を送信する
+# tmux 画面キャプチャを含めて、何を問われているかを明確に伝える
 
-# --- Load environment variables ---
-for ENV_FILE in "./.env" "$HOME/.config/ai-agents/profiles/default.env"; do
-  if [ -f "$ENV_FILE" ]; then
-    [ -z "$SLACK_NOTIFY_ENABLED" ] && SLACK_NOTIFY_ENABLED=$(grep '^SLACK_NOTIFY_ENABLED=' "$ENV_FILE" | cut -d'=' -f2)
-    [ -z "$SLACK_BOT_TOKEN" ] && SLACK_BOT_TOKEN=$(grep '^SLACK_BOT_TOKEN=' "$ENV_FILE" | cut -d'=' -f2)
-    [ -z "$SLACK_ALLOWED_USER" ] && SLACK_ALLOWED_USER=$(grep '^SLACK_ALLOWED_USER=' "$ENV_FILE" | cut -d'=' -f2)
-    [ -z "$TMUX_SESSION_NAME" ] && TMUX_SESSION_NAME=$(grep '^TMUX_SESSION_NAME=' "$ENV_FILE" | cut -d'=' -f2)
-  fi
-done
+ENV_FILE="$HOME/.config/ai-agents/profiles/default.env"
+
+# 環境変数読み込み
+if [ -f "$ENV_FILE" ]; then
+  SLACK_NOTIFY_ENABLED=$(grep '^SLACK_NOTIFY_ENABLED=' "$ENV_FILE" | cut -d'=' -f2)
+  SLACK_BOT_TOKEN=$(grep '^SLACK_BOT_TOKEN=' "$ENV_FILE" | cut -d'=' -f2)
+  SLACK_ALLOWED_USER=$(grep '^SLACK_ALLOWED_USER=' "$ENV_FILE" | cut -d'=' -f2)
+  TMUX_SESSION_NAME=$(grep '^TMUX_SESSION_NAME=' "$ENV_FILE" | cut -d'=' -f2)
+fi
 
 TMUX_SESSION_NAME="${TMUX_SESSION_NAME:-claude}"
 
-# Exit if disabled or missing config
+# 無効なら即終了
 [ "$SLACK_NOTIFY_ENABLED" = "true" ] || exit 0
 [ -n "$SLACK_BOT_TOKEN" ] || exit 0
 [ -n "$SLACK_ALLOWED_USER" ] || exit 0
 
-# Read JSON from stdin
+# stdin から JSON を読み取り
 INPUT=$(cat)
 
-# Build and send notification via Python
+# 環境変数を設定してからバックグラウンド実行
 export HOOK_INPUT="$INPUT"
 export TMUX_SESSION_NAME
 export BOT_TOKEN="$SLACK_BOT_TOKEN"
@@ -44,6 +34,7 @@ python3 << 'PYEOF'
 import json, subprocess, sys, os, urllib.request
 from datetime import datetime
 
+# 入力解析
 try:
     data = json.loads(os.environ.get("HOOK_INPUT", "{}"))
 except:
@@ -60,7 +51,7 @@ allowed_user = os.environ.get("ALLOWED_USER", "")
 if not bot_token or not allowed_user:
     sys.exit(0)
 
-# Auto-detect current tmux session name
+# 実行中の tmux セッション名を検出（環境変数 TMUX から自動判定）
 try:
     detect = subprocess.run(
         ["tmux", "display-message", "-p", "#{session_name}"],
@@ -71,7 +62,7 @@ try:
 except:
     pass
 
-# Capture tmux pane to show what Claude is actually asking
+# tmux 画面キャプチャ（末尾部分）- 実際の許可プロンプト内容を取得
 pane_content = ""
 try:
     result = subprocess.run(
@@ -84,32 +75,33 @@ try:
 except:
     pass
 
-# Build message (Block Kit)
-header_text = f":double_vertical_bar: *Waiting for input: {dir_name}*\n:speech_balloon: {message}\n:clock3: {time_str}"
+# メッセージ組み立て（Block Kit）
+header_text = f":double_vertical_bar: *入力待ち: {dir_name}*\n:speech_balloon: {message}\n:clock3: {time_str}"
 
 blocks = [
     {"type": "section", "text": {"type": "mrkdwn", "text": header_text}},
 ]
 
 if pane_content:
+    # Slack の code block は最大 3000 文字程度
     if len(pane_content) > 2500:
         pane_content = "...\n" + pane_content[-2500:]
     blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": f"```\n{pane_content}\n```"}})
 
-# Approve/Deny buttons (action_ids match hook_approve/hook_deny handlers in bot.py)
+# 許可/拒否ボタン（action_id は bot.py の hook_approve / hook_deny ハンドラに対応）
 blocks.append({
     "type": "actions",
     "elements": [
         {
             "type": "button",
-            "text": {"type": "plain_text", "text": "Approve (y)"},
+            "text": {"type": "plain_text", "text": "✅ 許可 (y)"},
             "action_id": "hook_approve",
             "value": tmux_session,
             "style": "primary",
         },
         {
             "type": "button",
-            "text": {"type": "plain_text", "text": "Deny (n)"},
+            "text": {"type": "plain_text", "text": "❌ 拒否 (n)"},
             "action_id": "hook_deny",
             "value": tmux_session,
             "style": "danger",
@@ -117,18 +109,20 @@ blocks.append({
     ],
 })
 
-fallback_text = f"Waiting for input: {dir_name} - {message}"
+fallback_text = f"入力待ち: {dir_name} - {message}"
 
-# Send via Bot DM
+# Bot DM で送信
 headers = {
     "Authorization": f"Bearer {bot_token}",
     "Content-Type": "application/json; charset=utf-8",
 }
 
+# conversations.open
 req = urllib.request.Request(
     "https://slack.com/api/conversations.open",
     data=json.dumps({"users": allowed_user}).encode("utf-8"),
-    headers=headers, method="POST",
+    headers=headers,
+    method="POST",
 )
 try:
     with urllib.request.urlopen(req, timeout=10) as resp:
@@ -139,6 +133,7 @@ except:
 if not channel_id:
     sys.exit(0)
 
+# chat.postMessage（Block Kit）
 payload = {
     "channel": channel_id,
     "text": fallback_text,
@@ -147,12 +142,14 @@ payload = {
 req2 = urllib.request.Request(
     "https://slack.com/api/chat.postMessage",
     data=json.dumps(payload).encode("utf-8"),
-    headers=headers, method="POST",
+    headers=headers,
+    method="POST",
 )
 try:
     urllib.request.urlopen(req2, timeout=10)
 except:
     pass
+
 PYEOF
 ) &
 


### PR DESCRIPTION
## Summary

- Remove quick menu system (`m`/`menu` command) and all associated button handlers
- Remove per-session y/n/status buttons from `sessions`/`ls` output
- Simplify `sessions`/`ls` to plain text list
- Add `last_assistant_message` summary to completion notifications
- Add tmux session auto-detection to hook scripts
- Add `_start_slack_bot()` auto-start helper for `tcc` function
- Update README to reflect simplified UX

**bot.py reduced from 629 to 282 lines (-55%)**

### Design principle

After real-world mobile usage, only **permission prompt buttons** (Approve/Deny) remain as interactive elements. Everything else is handled by text input with auto-session-routing, which is faster and simpler on a phone.

| Before | After |
|--------|-------|
| `m`/`menu` command with per-session buttons | Removed (type `y`, `n`, or any text directly) |
| `sessions`/`ls` with y/n/status buttons | Plain text list |
| Completion notification with status/menu buttons | Clean notification with response summary, no buttons |
| Permission notification with approve/deny buttons | **Kept** (only buttons in the system) |

## Test plan

- [ ] Send text message in Slack DM -> auto-routed to single session
- [ ] Send text with multiple sessions -> session picker buttons appear
- [ ] `status` command shows session info
- [ ] `sessions`/`ls` shows plain text list
- [ ] Permission prompt notification has Approve/Deny buttons that work
- [ ] Completion notification shows response summary without buttons
- [ ] `tcc` auto-starts bot.py

Fixes #1

Generated with [Claude Code](https://claude.com/claude-code)